### PR TITLE
meson: remove unused dbus option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,10 +3,3 @@ option(
     type: 'string',
     value: '/run/dinitctl',
 )
-
-option(
-    'dbus',
-    description: 'Whether to build the D-Bus interface',
-    type: 'feature',
-    value: 'auto',
-)


### PR DESCRIPTION
This option is no longer relevant since dbus functionality was moved into [chimera-linux/dinit-dbus](https://github.com/chimera-linux/dinit-dbus).

If you care about backwards compatibility, Meson's [deprecated option mechanism](https://mesonbuild.com/Build-options.html#deprecated-options) could be used here. It requires meson >=0.60.0 according to the linked documentation. I do not know what version of Meson does this project target.